### PR TITLE
Milestone 4: Taint Tracking Demo (Verified + Sanitizer + Sink)

### DIFF
--- a/src/demo.rs
+++ b/src/demo.rs
@@ -1,0 +1,370 @@
+//! End-to-end demonstration of taint tracking.
+//!
+//! This module demonstrates the complete flow of taint tracking:
+//! 1. Raw untrusted input is wrapped in `Tainted<T>` at the boundary
+//! 2. A `Sanitizer` validates and promotes to `Verified<T>`
+//! 3. A `Sink` accepts only `Verified<T>` and performs side effects
+//!
+//! # Security Properties
+//!
+//! - Untrusted data cannot reach sinks without sanitization (compile-time enforcement)
+//! - No implicit conversions allow bypassing the sanitizer
+//! - Sinks reject tainted data at runtime if explicitly passed to untrusted APIs
+//!
+//! # Example: User Input Pipeline
+//!
+//! ```ignore
+//! use policy_core::demo::process_user_input;
+//!
+//! // Simulate receiving untrusted user input
+//! let user_input = "  hello world  ";
+//!
+//! // Process through the taint tracking pipeline
+//! let result = process_user_input(user_input);
+//!
+//! // Valid input flows through successfully
+//! assert!(result.is_ok());
+//! let output = result.unwrap();
+//! assert_eq!(output, vec!["hello world"]); // Trimmed and verified
+//! ```
+//!
+//! # Compile-Time Rejection Example
+//!
+//! The following code will NOT compile, demonstrating type-level enforcement:
+//!
+//! ```compile_fail
+//! use policy_core::{Tainted, VecSink, Sink};
+//!
+//! let tainted = Tainted::new("unsafe data".to_string());
+//! let sink = VecSink::new();
+//!
+//! // This does not compile - type mismatch!
+//! // Expected &Verified<String>, got &Tainted<String>
+//! sink.sink(&tainted);
+//! ```
+
+use crate::{Sanitizer, Sink, StringSanitizer, Tainted, VecSink};
+
+/// Processes untrusted user input through the taint tracking pipeline.
+///
+/// This function demonstrates the canonical flow:
+/// 1. **Taint Origin**: Raw input is wrapped as `Tainted<String>` at the boundary
+/// 2. **Sanitization**: A `StringSanitizer` validates and promotes to `Verified<String>`
+/// 3. **Sink**: A `VecSink` accepts the verified value and stores it
+///
+/// # Arguments
+///
+/// * `raw_input` - Untrusted input string (e.g., from HTTP request, user form, etc.)
+///
+/// # Returns
+///
+/// Returns `Ok(Vec<String>)` containing the sanitized value on success,
+/// or `Err(String)` with an error description on failure.
+///
+/// # Security
+///
+/// This function enforces:
+/// - All input is treated as tainted at the boundary
+/// - Validation occurs before any side effects
+/// - Only verified data reaches the sink
+///
+/// # Examples
+///
+/// ```ignore
+/// use policy_core::demo::process_user_input;
+///
+/// // Valid input is sanitized and stored
+/// let result = process_user_input("  valid input  ");
+/// assert!(result.is_ok());
+/// assert_eq!(result.unwrap(), vec!["valid input"]);
+///
+/// // Empty input is rejected during sanitization
+/// let result = process_user_input("   ");
+/// assert!(result.is_err());
+///
+/// // Control characters are rejected
+/// let result = process_user_input("bad\ninput");
+/// assert!(result.is_err());
+/// ```
+#[allow(dead_code)]
+fn process_user_input(raw_input: &str) -> Result<Vec<String>, String> {
+    // Step 1: TAINT ORIGIN
+    // At the boundary, wrap untrusted input as Tainted<T>
+    // This marks it as requiring validation before use
+    let tainted = Tainted::new(raw_input.to_string());
+
+    // Step 2: SANITIZATION
+    // Use a real sanitizer to validate and promote to Verified<T>
+    // This is the ONLY way to create Verified<T> from Tainted<T>
+    let sanitizer = StringSanitizer::new(256);
+    let verified = sanitizer
+        .sanitize(tainted)
+        .map_err(|e| format!("Sanitization failed: {}", e))?;
+
+    // Step 3: SINK
+    // Pass verified value to a sink that accepts ONLY Verified<T>
+    // This performs the actual side effect (in this case, storage)
+    let sink = VecSink::new();
+    sink.sink(&verified)
+        .map_err(|e| format!("Sink failed: {}", e))?;
+
+    // Return the observable result
+    Ok(sink.into_vec())
+}
+
+/// Demonstrates batch processing of multiple untrusted inputs.
+///
+/// This function shows how to process multiple tainted values,
+/// accumulating only the successfully verified ones.
+///
+/// # Arguments
+///
+/// * `raw_inputs` - Collection of untrusted input strings
+///
+/// # Returns
+///
+/// Returns a tuple of (successes, failures) where:
+/// - `successes` contains all sanitized values
+/// - `failures` contains error messages for rejected inputs
+///
+/// # Examples
+///
+/// ```ignore
+/// use policy_core::demo::batch_process_inputs;
+///
+/// let inputs = vec![
+///     "  valid1  ",
+///     "",              // Empty - will fail
+///     "valid2",
+///     "bad\ndata",     // Control char - will fail
+///     "  valid3  ",
+/// ];
+///
+/// let (successes, failures) = batch_process_inputs(&inputs);
+///
+/// assert_eq!(successes, vec!["valid1", "valid2", "valid3"]);
+/// assert_eq!(failures.len(), 2);
+/// ```
+#[allow(dead_code)]
+fn batch_process_inputs(raw_inputs: &[&str]) -> (Vec<String>, Vec<String>) {
+    let sanitizer = StringSanitizer::new(256);
+    let sink = VecSink::new();
+
+    let mut failures = Vec::new();
+
+    for raw_input in raw_inputs {
+        // Taint each input at the boundary
+        let tainted = Tainted::new(raw_input.to_string());
+
+        // Attempt sanitization
+        match sanitizer.sanitize(tainted) {
+            Ok(verified) => {
+                // Only verified values reach the sink
+                if let Err(e) = sink.sink(&verified) {
+                    failures.push(format!("Sink error: {}", e));
+                }
+            }
+            Err(e) => {
+                // Collect sanitization failures (without leaking input)
+                failures.push(format!("Sanitization failed: {}", e.kind()));
+            }
+        }
+    }
+
+    (sink.into_vec(), failures)
+}
+
+/// Demonstrates explicit runtime rejection of untrusted data.
+///
+/// This function shows what happens when code attempts to bypass sanitization
+/// by calling the explicit "untrusted" API on a sink.
+///
+/// # Returns
+///
+/// Always returns `Err` because tainted values cannot be sunk without sanitization.
+///
+/// # Examples
+///
+/// ```ignore
+/// use policy_core::demo::attempt_bypass;
+///
+/// let result = attempt_bypass("malicious input");
+///
+/// // Attempt is rejected at runtime
+/// assert!(result.is_err());
+/// let err = result.unwrap_err();
+/// assert!(err.contains("Rejected"));
+/// assert!(err.contains("unverified"));
+/// ```
+#[allow(dead_code)]
+fn attempt_bypass(raw_input: &str) -> Result<Vec<String>, String> {
+    let tainted = Tainted::new(raw_input.to_string());
+    let sink = VecSink::new();
+
+    // Attempt to bypass sanitization using the explicit untrusted API
+    // This will ALWAYS fail - demonstrating runtime rejection
+    sink.sink_untrusted(tainted)
+        .map_err(|e| format!("Rejected: {}", e.kind()))?;
+
+    Ok(sink.into_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn end_to_end_happy_path() {
+        // Simulate receiving untrusted input from a user
+        let user_input = "  Hello, World!  ";
+
+        // Process through the complete pipeline
+        let result = process_user_input(user_input);
+
+        // Should succeed and contain the sanitized value
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        assert_eq!(output.len(), 1);
+        assert_eq!(output[0], "Hello, World!"); // Trimmed but preserved
+    }
+
+    #[test]
+    fn end_to_end_sanitization_trims() {
+        let result = process_user_input("  test  ");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), vec!["test"]);
+    }
+
+    #[test]
+    fn end_to_end_rejects_empty() {
+        // Empty input should be rejected during sanitization
+        let result = process_user_input("   ");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Sanitization failed"));
+    }
+
+    #[test]
+    fn end_to_end_rejects_control_chars() {
+        // Newlines should be rejected during sanitization
+        let result = process_user_input("hello\nworld");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Sanitization failed"));
+    }
+
+    #[test]
+    fn end_to_end_rejects_null_bytes() {
+        // Null bytes should be rejected during sanitization
+        let result = process_user_input("hello\0world");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Sanitization failed"));
+    }
+
+    #[test]
+    fn end_to_end_rejects_too_long() {
+        // Very long input exceeding max length
+        let long_input = "x".repeat(1000);
+        let result = process_user_input(&long_input);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Sanitization failed"));
+    }
+
+    #[test]
+    fn batch_processing_filters_correctly() {
+        let long_input = "x".repeat(300);
+        let inputs = vec![
+            "  valid1  ",
+            "", // Empty - will fail
+            "valid2",
+            "bad\ndata", // Control char - will fail
+            "  valid3  ",
+            long_input.as_str(), // Too long - will fail
+        ];
+
+        let (successes, failures) = batch_process_inputs(&inputs);
+
+        // Only the three valid inputs should succeed
+        assert_eq!(successes.len(), 3);
+        assert_eq!(successes, vec!["valid1", "valid2", "valid3"]);
+
+        // Three inputs should have failed
+        assert_eq!(failures.len(), 3);
+    }
+
+    #[test]
+    fn batch_processing_preserves_order() {
+        let inputs = vec!["first", "second", "third"];
+        let (successes, _) = batch_process_inputs(&inputs);
+        assert_eq!(successes, vec!["first", "second", "third"]);
+    }
+
+    #[test]
+    fn runtime_rejection_fails() {
+        // Attempting to bypass sanitization should fail
+        let result = attempt_bypass("any input");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("Rejected"));
+        assert!(err.contains("unverified"));
+    }
+
+    #[test]
+    fn runtime_rejection_no_side_effects() {
+        // Create a sink and verify it's empty
+        let sink = VecSink::new();
+        assert_eq!(sink.len(), 0);
+
+        // Attempt to sink tainted data via untrusted API
+        let tainted = Tainted::new("malicious".to_string());
+        let result = sink.sink_untrusted(tainted);
+
+        // Should fail
+        assert!(result.is_err());
+
+        // Should NOT have modified the sink
+        assert_eq!(sink.len(), 0);
+        assert!(sink.is_empty());
+    }
+
+    #[test]
+    fn compile_time_rejection_documented() {
+        // This test documents that the following code would NOT compile:
+        //
+        // let raw_input = "unsafe".to_string();
+        // let sink = VecSink::new();
+        // sink.sink(&raw_input); // ← Type error! Expected &Verified<String>, got &String
+        //
+        // let tainted = Tainted::new("unsafe".to_string());
+        // sink.sink(&tainted); // ← Type error! Expected &Verified<String>, got &Tainted<String>
+        //
+        // The type system prevents these calls at compile time.
+        // Only this works:
+        let sanitizer = StringSanitizer::new(256);
+        let tainted = Tainted::new("safe".to_string());
+        let verified = sanitizer.sanitize(tainted).unwrap();
+        let sink = VecSink::new();
+        sink.sink(&verified).unwrap(); // ✓ Compiles - verified type
+    }
+
+    #[test]
+    fn unicode_flows_through_pipeline() {
+        let result = process_user_input("  Hello 世界 🌍  ");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), vec!["Hello 世界 🌍"]);
+    }
+
+    #[test]
+    fn error_messages_do_not_leak_input() {
+        // Process input that will be rejected (contains newline - a control character)
+        let secret_input = "SECRET_API_KEY\n12345";
+        let result = process_user_input(secret_input);
+
+        assert!(result.is_err());
+        let error_msg = result.unwrap_err();
+
+        // Error message should NOT contain the actual secret
+        assert!(!error_msg.contains("SECRET_API_KEY"));
+        assert!(!error_msg.contains("12345"));
+        // But should contain useful information
+        assert!(error_msg.contains("Sanitization failed"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,9 @@
 //!
 //! - [`Secret<T>`]: Wrapper that redacts sensitive values in logs/output
 //! - [`Tainted<T>`]: Wrapper for untrusted data requiring sanitization
+//! - [`Verified<T>`]: Wrapper for validated/sanitized data safe to use
+//! - [`Sanitizer<T>`]: Trait for sanitizing tainted values into verified values
+//! - [`Sink<T>`]: Trait for operations that accept only verified values
 //! - [`Ctx`]: Validated execution context holding capabilities
 //! - [`LogCap`]: Capability proving authorization for logging operations
 //! - [`PolicyGate`]: Builder for validating policies and creating contexts
@@ -43,13 +46,17 @@
 
 mod capability;
 mod context;
+mod demo;
 mod error;
 mod gate;
 mod logging;
 mod policy;
 mod request;
+mod sanitizer;
 mod secret;
+mod sink;
 mod tainted;
+mod verified;
 
 pub use capability::{LogCap, log_with_capability};
 pub use context::Ctx;
@@ -58,5 +65,11 @@ pub use gate::PolicyGate;
 pub use logging::PolicyLog;
 pub use policy::{Authenticated, Authorized};
 pub use request::{Principal, RequestMeta};
+pub use sanitizer::{
+    AcceptAllSanitizer, RejectAllSanitizer, SanitizationError, SanitizationErrorKind, Sanitizer,
+    StringSanitizer,
+};
 pub use secret::Secret;
+pub use sink::{Sink, SinkError, SinkErrorKind, VecSink};
 pub use tainted::Tainted;
+pub use verified::Verified;

--- a/src/sanitizer.rs
+++ b/src/sanitizer.rs
@@ -1,0 +1,591 @@
+use std::fmt;
+
+use crate::{Tainted, Verified};
+
+/// Error returned when sanitization fails.
+///
+/// This error indicates that a tainted value failed validation and could not
+/// be promoted to a `Verified<T>`. The error does not leak sensitive information
+/// about the rejected input.
+///
+/// # Examples
+///
+/// ```
+/// use policy_core::{SanitizationError, SanitizationErrorKind};
+///
+/// let error = SanitizationError::new(SanitizationErrorKind::InvalidInput, "value too long");
+/// assert_eq!(error.kind(), SanitizationErrorKind::InvalidInput);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SanitizationError {
+    kind: SanitizationErrorKind,
+    message: String,
+}
+
+impl SanitizationError {
+    /// Creates a new sanitization error.
+    pub fn new(kind: SanitizationErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+
+    /// Returns the error kind.
+    pub fn kind(&self) -> SanitizationErrorKind {
+        self.kind
+    }
+
+    /// Returns the error message.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl fmt::Display for SanitizationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "sanitization failed ({}): {}", self.kind, self.message)
+    }
+}
+
+impl std::error::Error for SanitizationError {}
+
+/// Kind of sanitization error.
+///
+/// Categorizes why sanitization failed without leaking sensitive details.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SanitizationErrorKind {
+    /// Input failed validation rules.
+    InvalidInput,
+    /// Input contains forbidden patterns.
+    ForbiddenPattern,
+    /// Input format is malformed.
+    MalformedInput,
+    /// Input is empty or contains only whitespace.
+    Empty,
+    /// Input exceeds maximum allowed length.
+    TooLong,
+    /// Input contains control or non-printable characters.
+    ContainsControlChars,
+}
+
+impl fmt::Display for SanitizationErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidInput => write!(f, "invalid input"),
+            Self::ForbiddenPattern => write!(f, "forbidden pattern"),
+            Self::MalformedInput => write!(f, "malformed input"),
+            Self::Empty => write!(f, "empty input"),
+            Self::TooLong => write!(f, "input too long"),
+            Self::ContainsControlChars => write!(f, "contains control characters"),
+        }
+    }
+}
+
+/// Trait for sanitizing tainted values into verified values.
+///
+/// `Sanitizer<T>` defines the interface for converting untrusted, tainted data
+/// into verified data that is safe to use in security-sensitive contexts.
+///
+/// # Invariants
+///
+/// Implementations MUST:
+/// - Validate/sanitize the input according to their policy rules
+/// - Only call `Verified::new_unchecked` after validation succeeds
+/// - Return `Err(SanitizationError)` if validation fails
+/// - Not leak sensitive information in errors
+///
+/// # Examples
+///
+/// ```
+/// use policy_core::{Tainted, Verified, Sanitizer, SanitizationError};
+///
+/// // Sanitizers will be used like this:
+/// # struct MySanitizer;
+/// # impl Sanitizer<String> for MySanitizer {
+/// #     fn sanitize(&self, input: Tainted<String>) -> Result<Verified<String>, SanitizationError> {
+/// #         unimplemented!()
+/// #     }
+/// # }
+/// let sanitizer = MySanitizer;
+/// let tainted_input = Tainted::new("some untrusted data".to_string());
+///
+/// // Sanitizer performs validation and returns Verified on success
+/// // let verified = sanitizer.sanitize(tainted_input)?;
+/// ```
+pub trait Sanitizer<T> {
+    /// Sanitizes a tainted value, returning a verified value on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns `SanitizationError` if the input fails validation.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// # use policy_core::{Tainted, Sanitizer};
+    /// # let sanitizer = todo!();
+    /// let tainted = Tainted::new("input".to_string());
+    /// let verified = sanitizer.sanitize(tainted)?;
+    /// ```
+    fn sanitize(&self, input: Tainted<T>) -> Result<Verified<T>, SanitizationError>;
+}
+
+/// A trivial sanitizer that accepts all input (for testing only).
+///
+/// **WARNING:** This sanitizer performs NO validation and should only be used
+/// in tests or as a placeholder. It unconditionally promotes tainted values
+/// to verified values.
+///
+/// # Examples
+///
+/// ```
+/// use policy_core::{Tainted, Sanitizer, AcceptAllSanitizer};
+///
+/// let sanitizer = AcceptAllSanitizer;
+/// let tainted = Tainted::new("any value".to_string());
+/// let verified = sanitizer.sanitize(tainted).expect("always succeeds");
+///
+/// assert_eq!(verified.as_ref(), "any value");
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct AcceptAllSanitizer;
+
+impl<T> Sanitizer<T> for AcceptAllSanitizer {
+    fn sanitize(&self, input: Tainted<T>) -> Result<Verified<T>, SanitizationError> {
+        // Extract the inner value from the tainted wrapper
+        let value = input.into_inner();
+        // Unconditionally wrap it as verified (no validation!)
+        Ok(Verified::new_unchecked(value))
+    }
+}
+
+/// A trivial sanitizer that rejects all input (for testing only).
+///
+/// This sanitizer always fails validation, useful for testing error paths.
+///
+/// # Examples
+///
+/// ```
+/// use policy_core::{Tainted, Sanitizer, RejectAllSanitizer, SanitizationErrorKind};
+///
+/// let sanitizer = RejectAllSanitizer;
+/// let tainted = Tainted::new("any value".to_string());
+/// let result = sanitizer.sanitize(tainted);
+///
+/// assert!(result.is_err());
+/// assert_eq!(result.unwrap_err().kind(), SanitizationErrorKind::InvalidInput);
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct RejectAllSanitizer;
+
+impl<T> Sanitizer<T> for RejectAllSanitizer {
+    fn sanitize(&self, _input: Tainted<T>) -> Result<Verified<T>, SanitizationError> {
+        Err(SanitizationError::new(
+            SanitizationErrorKind::InvalidInput,
+            "rejected by policy",
+        ))
+    }
+}
+
+/// A string sanitizer that enforces basic safety and length constraints.
+///
+/// This sanitizer validates and normalizes untrusted string input by:
+/// - Trimming leading and trailing whitespace
+/// - Rejecting empty strings (after trimming)
+/// - Rejecting strings containing control or non-printable characters
+/// - Enforcing a maximum length constraint (default: 256 characters)
+///
+/// # Security Properties
+///
+/// - Prevents injection of control characters (newlines, null bytes, etc.)
+/// - Ensures non-empty meaningful input
+/// - Prevents excessive memory consumption via length limits
+/// - Does not leak rejected input in error messages
+///
+/// # Examples
+///
+/// ```
+/// use policy_core::{Tainted, Sanitizer, StringSanitizer};
+///
+/// // Valid input with whitespace is trimmed
+/// let sanitizer = StringSanitizer::new(256);
+/// let tainted = Tainted::new("  hello world  ".to_string());
+/// let verified = sanitizer.sanitize(tainted).expect("should succeed");
+/// assert_eq!(verified.as_ref(), "hello world");
+///
+/// // Empty input (after trimming) is rejected
+/// let tainted = Tainted::new("   ".to_string());
+/// assert!(sanitizer.sanitize(tainted).is_err());
+///
+/// // Control characters are rejected
+/// let tainted = Tainted::new("hello\nworld".to_string());
+/// assert!(sanitizer.sanitize(tainted).is_err());
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct StringSanitizer {
+    max_len: usize,
+}
+
+impl StringSanitizer {
+    /// Creates a new string sanitizer with the specified maximum length.
+    ///
+    /// # Arguments
+    ///
+    /// * `max_len` - Maximum allowed length for the sanitized string (must be > 0)
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_len` is 0.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use policy_core::StringSanitizer;
+    ///
+    /// let sanitizer = StringSanitizer::new(100);
+    /// ```
+    pub fn new(max_len: usize) -> Self {
+        assert!(max_len > 0, "max_len must be greater than 0");
+        Self { max_len }
+    }
+
+    /// Creates a string sanitizer with the default maximum length of 256 characters.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use policy_core::StringSanitizer;
+    ///
+    /// let sanitizer = StringSanitizer::default_limits();
+    /// ```
+    pub fn default_limits() -> Self {
+        Self::new(256)
+    }
+
+    /// Checks if a character is a control or non-printable character.
+    ///
+    /// Returns `true` for:
+    /// - ASCII control characters (0x00-0x1F)
+    /// - Delete character (0x7F)
+    /// - Other non-printable Unicode characters
+    fn is_control_char(c: char) -> bool {
+        c.is_control() || c == '\u{007F}'
+    }
+}
+
+impl Sanitizer<String> for StringSanitizer {
+    fn sanitize(&self, input: Tainted<String>) -> Result<Verified<String>, SanitizationError> {
+        // Extract the raw string from the tainted wrapper
+        let raw = input.into_inner();
+
+        // Trim leading and trailing whitespace
+        let trimmed = raw.trim();
+
+        // Reject empty strings (after trimming)
+        if trimmed.is_empty() {
+            return Err(SanitizationError::new(
+                SanitizationErrorKind::Empty,
+                "input is empty or contains only whitespace",
+            ));
+        }
+
+        // Check for control or non-printable characters
+        if trimmed.chars().any(Self::is_control_char) {
+            return Err(SanitizationError::new(
+                SanitizationErrorKind::ContainsControlChars,
+                "input contains control or non-printable characters",
+            ));
+        }
+
+        // Check length constraint
+        if trimmed.len() > self.max_len {
+            return Err(SanitizationError::new(
+                SanitizationErrorKind::TooLong,
+                format!("input exceeds maximum length of {}", self.max_len),
+            ));
+        }
+
+        // All validation passed - create verified value
+        Ok(Verified::new_unchecked(trimmed.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitization_error_creation() {
+        let error = SanitizationError::new(SanitizationErrorKind::InvalidInput, "test message");
+
+        assert_eq!(error.kind(), SanitizationErrorKind::InvalidInput);
+        assert_eq!(error.message(), "test message");
+    }
+
+    #[test]
+    fn sanitization_error_display() {
+        let error = SanitizationError::new(SanitizationErrorKind::ForbiddenPattern, "contains SQL");
+
+        let output = format!("{}", error);
+        assert!(output.contains("sanitization failed"));
+        assert!(output.contains("forbidden pattern"));
+        assert!(output.contains("contains SQL"));
+    }
+
+    #[test]
+    fn accept_all_sanitizer_succeeds() {
+        let sanitizer = AcceptAllSanitizer;
+        let tainted = Tainted::new("test input".to_string());
+
+        let result = sanitizer.sanitize(tainted);
+
+        assert!(result.is_ok());
+        let verified = result.unwrap();
+        assert_eq!(verified.as_ref(), "test input");
+    }
+
+    #[test]
+    fn accept_all_sanitizer_preserves_value() {
+        let sanitizer = AcceptAllSanitizer;
+        let tainted = Tainted::new(vec![1, 2, 3, 4, 5]);
+
+        let verified = sanitizer.sanitize(tainted).expect("should succeed");
+
+        assert_eq!(verified.as_ref(), &vec![1, 2, 3, 4, 5]);
+        assert_eq!(verified.into_inner(), vec![1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn reject_all_sanitizer_fails() {
+        let sanitizer = RejectAllSanitizer;
+        let tainted = Tainted::new("test input".to_string());
+
+        let result = sanitizer.sanitize(tainted);
+
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(error.kind(), SanitizationErrorKind::InvalidInput);
+        assert_eq!(error.message(), "rejected by policy");
+    }
+
+    #[test]
+    fn sanitizer_enforces_tainted_input() {
+        // This test documents that sanitize() requires Tainted<T> input
+        let sanitizer = AcceptAllSanitizer;
+        let tainted = Tainted::new(42);
+
+        // This works:
+        let _verified = sanitizer.sanitize(tainted);
+
+        // This would NOT compile if uncommented (good!):
+        // let raw_value = 42;
+        // let verified = sanitizer.sanitize(raw_value); // Type mismatch!
+    }
+
+    #[test]
+    fn sanitizer_returns_verified_output() {
+        let sanitizer = AcceptAllSanitizer;
+        let tainted = Tainted::new("data".to_string());
+
+        let verified = sanitizer.sanitize(tainted).expect("should succeed");
+
+        // Verified can be accessed via AsRef
+        let _: &String = verified.as_ref();
+
+        // Or consumed
+        let _: String = verified.into_inner();
+    }
+
+    #[test]
+    fn error_kinds_display() {
+        assert_eq!(
+            format!("{}", SanitizationErrorKind::InvalidInput),
+            "invalid input"
+        );
+        assert_eq!(
+            format!("{}", SanitizationErrorKind::ForbiddenPattern),
+            "forbidden pattern"
+        );
+        assert_eq!(
+            format!("{}", SanitizationErrorKind::MalformedInput),
+            "malformed input"
+        );
+        assert_eq!(format!("{}", SanitizationErrorKind::Empty), "empty input");
+        assert_eq!(
+            format!("{}", SanitizationErrorKind::TooLong),
+            "input too long"
+        );
+        assert_eq!(
+            format!("{}", SanitizationErrorKind::ContainsControlChars),
+            "contains control characters"
+        );
+    }
+
+    // StringSanitizer tests
+
+    #[test]
+    fn string_sanitizer_accepts_valid_input() {
+        let sanitizer = StringSanitizer::new(256);
+        let tainted = Tainted::new("hello world".to_string());
+
+        let result = sanitizer.sanitize(tainted);
+
+        assert!(result.is_ok());
+        let verified = result.unwrap();
+        assert_eq!(verified.as_ref(), "hello world");
+    }
+
+    #[test]
+    fn string_sanitizer_trims_whitespace() {
+        let sanitizer = StringSanitizer::new(256);
+        let tainted = Tainted::new("  hello world  ".to_string());
+
+        let verified = sanitizer.sanitize(tainted).expect("should succeed");
+
+        assert_eq!(verified.as_ref(), "hello world");
+    }
+
+    #[test]
+    fn string_sanitizer_rejects_empty_string() {
+        let sanitizer = StringSanitizer::new(256);
+        let tainted = Tainted::new("".to_string());
+
+        let result = sanitizer.sanitize(tainted);
+
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(error.kind(), SanitizationErrorKind::Empty);
+    }
+
+    #[test]
+    fn string_sanitizer_rejects_whitespace_only() {
+        let sanitizer = StringSanitizer::new(256);
+        let tainted = Tainted::new("   \t\t  ".to_string());
+
+        let result = sanitizer.sanitize(tainted);
+
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(error.kind(), SanitizationErrorKind::Empty);
+    }
+
+    #[test]
+    fn string_sanitizer_rejects_newline() {
+        let sanitizer = StringSanitizer::new(256);
+        let tainted = Tainted::new("hello\nworld".to_string());
+
+        let result = sanitizer.sanitize(tainted);
+
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(error.kind(), SanitizationErrorKind::ContainsControlChars);
+    }
+
+    #[test]
+    fn string_sanitizer_rejects_null_byte() {
+        let sanitizer = StringSanitizer::new(256);
+        let tainted = Tainted::new("hello\0world".to_string());
+
+        let result = sanitizer.sanitize(tainted);
+
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(error.kind(), SanitizationErrorKind::ContainsControlChars);
+    }
+
+    #[test]
+    fn string_sanitizer_rejects_carriage_return() {
+        let sanitizer = StringSanitizer::new(256);
+        let tainted = Tainted::new("hello\rworld".to_string());
+
+        let result = sanitizer.sanitize(tainted);
+
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(error.kind(), SanitizationErrorKind::ContainsControlChars);
+    }
+
+    #[test]
+    fn string_sanitizer_rejects_tab() {
+        let sanitizer = StringSanitizer::new(256);
+        let tainted = Tainted::new("hello\tworld".to_string());
+
+        let result = sanitizer.sanitize(tainted);
+
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(error.kind(), SanitizationErrorKind::ContainsControlChars);
+    }
+
+    #[test]
+    fn string_sanitizer_rejects_too_long() {
+        let sanitizer = StringSanitizer::new(10);
+        let tainted = Tainted::new("this is a very long string".to_string());
+
+        let result = sanitizer.sanitize(tainted);
+
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(error.kind(), SanitizationErrorKind::TooLong);
+        assert!(error.message().contains("10"));
+    }
+
+    #[test]
+    fn string_sanitizer_accepts_at_max_length() {
+        let sanitizer = StringSanitizer::new(10);
+        let tainted = Tainted::new("exactly10!".to_string());
+
+        let result = sanitizer.sanitize(tainted);
+
+        assert!(result.is_ok());
+        let verified = result.unwrap();
+        assert_eq!(verified.as_ref(), "exactly10!");
+    }
+
+    #[test]
+    fn string_sanitizer_default_limits() {
+        let sanitizer = StringSanitizer::default_limits();
+        let tainted = Tainted::new("test".to_string());
+
+        let result = sanitizer.sanitize(tainted);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn string_sanitizer_accepts_unicode() {
+        let sanitizer = StringSanitizer::new(256);
+        let tainted = Tainted::new("Hello 世界 🌍".to_string());
+
+        let result = sanitizer.sanitize(tainted);
+
+        assert!(result.is_ok());
+        let verified = result.unwrap();
+        assert_eq!(verified.as_ref(), "Hello 世界 🌍");
+    }
+
+    #[test]
+    fn string_sanitizer_error_does_not_leak_input() {
+        let sanitizer = StringSanitizer::new(10);
+        let secret_input = "SECRET_PASSWORD_12345";
+        let tainted = Tainted::new(secret_input.to_string());
+
+        let result = sanitizer.sanitize(tainted);
+
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        let error_message = format!("{}", error);
+
+        // Error message should NOT contain the actual secret input
+        assert!(!error_message.contains(secret_input));
+        // But should contain useful information about the constraint
+        assert!(error_message.contains("10"));
+    }
+
+    #[test]
+    #[should_panic(expected = "max_len must be greater than 0")]
+    fn string_sanitizer_panics_on_zero_max_len() {
+        let _sanitizer = StringSanitizer::new(0);
+    }
+}

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -1,0 +1,457 @@
+use std::cell::RefCell;
+use std::fmt;
+
+use crate::{Tainted, Verified};
+
+/// Error returned when sinking a value fails.
+///
+/// This error indicates that a value could not be written to a sink, either
+/// due to an I/O error or because the value was not properly verified.
+///
+/// # Examples
+///
+/// ```
+/// use policy_core::{SinkError, SinkErrorKind};
+///
+/// let error = SinkError::new(SinkErrorKind::Unverified);
+/// assert_eq!(error.kind(), SinkErrorKind::Unverified);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SinkError {
+    kind: SinkErrorKind,
+    message: Option<String>,
+}
+
+impl SinkError {
+    /// Creates a new sink error with the specified kind.
+    pub fn new(kind: SinkErrorKind) -> Self {
+        Self {
+            kind,
+            message: None,
+        }
+    }
+
+    /// Creates a new sink error with a custom message.
+    pub fn with_message(kind: SinkErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: Some(message.into()),
+        }
+    }
+
+    /// Returns the error kind.
+    pub fn kind(&self) -> SinkErrorKind {
+        self.kind
+    }
+
+    /// Returns the error message, if any.
+    pub fn message(&self) -> Option<&str> {
+        self.message.as_deref()
+    }
+}
+
+impl fmt::Display for SinkError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(msg) = &self.message {
+            write!(f, "sink error ({}): {}", self.kind, msg)
+        } else {
+            write!(f, "sink error ({})", self.kind)
+        }
+    }
+}
+
+impl std::error::Error for SinkError {}
+
+/// Kind of sink error.
+///
+/// Categorizes why a sink operation failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SinkErrorKind {
+    /// Value was not verified before sinking.
+    Unverified,
+    /// I/O error occurred during sink operation.
+    Io,
+    /// Sink is full or has reached capacity.
+    Full,
+}
+
+impl fmt::Display for SinkErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unverified => write!(f, "unverified input"),
+            Self::Io => write!(f, "I/O error"),
+            Self::Full => write!(f, "sink full"),
+        }
+    }
+}
+
+/// Trait for sinks that accept only verified values.
+///
+/// `Sink<T>` defines the interface for writing verified data to side-effecting
+/// operations (files, logs, databases, etc.). The trait enforces at compile time
+/// that only `Verified<T>` values can be written, preventing tainted data from
+/// flowing into sinks.
+///
+/// # Compile-Time Safety
+///
+/// The `sink` method accepts only `&Verified<T>`, which means:
+/// - Raw values of type `T` cannot be sunk directly (compile error)
+/// - `Tainted<T>` values cannot be sunk directly (compile error)
+/// - Only values that have passed through a `Sanitizer` can be sunk
+///
+/// # Examples
+///
+/// ```
+/// use policy_core::{Tainted, Verified, Sanitizer, Sink, VecSink, StringSanitizer};
+///
+/// let sink = VecSink::new();
+/// let sanitizer = StringSanitizer::new(256);
+///
+/// // Tainted input must be sanitized first
+/// let tainted = Tainted::new("hello world".to_string());
+/// let verified = sanitizer.sanitize(tainted).expect("should succeed");
+///
+/// // Verified values can be sunk
+/// sink.sink(&verified).expect("should succeed");
+///
+/// // This would NOT compile:
+/// // let tainted = Tainted::new("bad".to_string());
+/// // sink.sink(&tainted); // Type mismatch!
+/// ```
+pub trait Sink<T> {
+    /// Writes a verified value to the sink.
+    ///
+    /// # Errors
+    ///
+    /// Returns `SinkError` if the sink operation fails (e.g., I/O error, capacity exceeded).
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use policy_core::{Verified, Sink, VecSink};
+    ///
+    /// # let sink = VecSink::new();
+    /// # let verified = Verified::new_unchecked("data".to_string());
+    /// // Only verified values can be sunk
+    /// sink.sink(&verified).expect("should succeed");
+    /// ```
+    fn sink(&self, value: &Verified<T>) -> Result<(), SinkError>;
+
+    /// Attempts to sink an unverified value (always fails).
+    ///
+    /// This method provides a runtime rejection path for tainted values.
+    /// It exists primarily for demonstration and explicit error handling,
+    /// as tainted values should be rejected at compile time via the type system.
+    ///
+    /// # Errors
+    ///
+    /// Always returns `SinkError` with kind `Unverified`, as tainted values
+    /// must be sanitized before sinking.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use policy_core::{Tainted, Sink, VecSink, SinkErrorKind};
+    ///
+    /// let sink = VecSink::new();
+    /// let tainted = Tainted::new("unsafe".to_string());
+    ///
+    /// let result = sink.sink_untrusted(tainted);
+    /// assert!(result.is_err());
+    /// assert_eq!(result.unwrap_err().kind(), SinkErrorKind::Unverified);
+    /// ```
+    fn sink_untrusted(&self, _value: Tainted<T>) -> Result<(), SinkError> {
+        Err(SinkError::new(SinkErrorKind::Unverified))
+    }
+}
+
+/// A demonstration sink that collects verified strings into an in-memory vector.
+///
+/// `VecSink` provides a simple, observable sink for testing and demonstration.
+/// It accepts only `Verified<String>` values and stores them in an internal vector.
+///
+/// # Security Properties
+///
+/// - Accepts only `Verified<String>` on the main path (compile-time enforcement)
+/// - Rejects `Tainted<String>` at runtime if `sink_untrusted` is called
+/// - Does not perform sanitization itself (delegates to `Sanitizer` implementations)
+/// - Uses interior mutability to allow shared access while collecting values
+///
+/// # Examples
+///
+/// ```
+/// use policy_core::{Tainted, Verified, Sanitizer, Sink, VecSink, StringSanitizer};
+///
+/// let sink = VecSink::new();
+/// let sanitizer = StringSanitizer::new(256);
+///
+/// // Sanitize and sink verified values
+/// let tainted = Tainted::new("  hello  ".to_string());
+/// let verified = sanitizer.sanitize(tainted).expect("valid input");
+/// sink.sink(&verified).expect("should succeed");
+///
+/// // Check collected values
+/// let values = sink.into_vec();
+/// assert_eq!(values, vec!["hello"]);
+/// ```
+#[derive(Debug)]
+pub struct VecSink {
+    values: RefCell<Vec<String>>,
+}
+
+impl VecSink {
+    /// Creates a new empty vector sink.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use policy_core::VecSink;
+    ///
+    /// let sink = VecSink::new();
+    /// ```
+    pub fn new() -> Self {
+        Self {
+            values: RefCell::new(Vec::new()),
+        }
+    }
+
+    /// Returns the number of values in the sink.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use policy_core::VecSink;
+    ///
+    /// let sink = VecSink::new();
+    /// assert_eq!(sink.len(), 0);
+    /// ```
+    pub fn len(&self) -> usize {
+        self.values.borrow().len()
+    }
+
+    /// Returns `true` if the sink contains no values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use policy_core::VecSink;
+    ///
+    /// let sink = VecSink::new();
+    /// assert!(sink.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.values.borrow().is_empty()
+    }
+
+    /// Consumes the sink and returns the collected values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use policy_core::VecSink;
+    ///
+    /// let sink = VecSink::new();
+    /// let values = sink.into_vec();
+    /// assert_eq!(values.len(), 0);
+    /// ```
+    pub fn into_vec(self) -> Vec<String> {
+        self.values.into_inner()
+    }
+
+    /// Returns a snapshot of the current values in the sink.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use policy_core::VecSink;
+    ///
+    /// let sink = VecSink::new();
+    /// let values = sink.to_vec();
+    /// assert!(values.is_empty());
+    /// ```
+    pub fn to_vec(&self) -> Vec<String> {
+        self.values.borrow().clone()
+    }
+}
+
+impl Default for VecSink {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Sink<String> for VecSink {
+    fn sink(&self, value: &Verified<String>) -> Result<(), SinkError> {
+        // Extract the verified string and push it to the vector
+        let verified_str = value.as_ref();
+        self.values.borrow_mut().push(verified_str.clone());
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Sanitizer, StringSanitizer};
+
+    #[test]
+    fn sink_error_creation() {
+        let error = SinkError::new(SinkErrorKind::Unverified);
+        assert_eq!(error.kind(), SinkErrorKind::Unverified);
+        assert_eq!(error.message(), None);
+    }
+
+    #[test]
+    fn sink_error_with_message() {
+        let error = SinkError::with_message(SinkErrorKind::Io, "disk full");
+        assert_eq!(error.kind(), SinkErrorKind::Io);
+        assert_eq!(error.message(), Some("disk full"));
+    }
+
+    #[test]
+    fn sink_error_display() {
+        let error = SinkError::new(SinkErrorKind::Unverified);
+        let output = format!("{}", error);
+        assert!(output.contains("unverified input"));
+    }
+
+    #[test]
+    fn sink_error_kinds_display() {
+        assert_eq!(format!("{}", SinkErrorKind::Unverified), "unverified input");
+        assert_eq!(format!("{}", SinkErrorKind::Io), "I/O error");
+        assert_eq!(format!("{}", SinkErrorKind::Full), "sink full");
+    }
+
+    #[test]
+    fn vec_sink_accepts_verified() {
+        let sink = VecSink::new();
+        let verified = Verified::new_unchecked("test".to_string());
+
+        let result = sink.sink(&verified);
+
+        assert!(result.is_ok());
+        assert_eq!(sink.len(), 1);
+        assert_eq!(sink.to_vec(), vec!["test"]);
+    }
+
+    #[test]
+    fn vec_sink_multiple_values() {
+        let sink = VecSink::new();
+
+        for i in 0..5 {
+            let verified = Verified::new_unchecked(format!("value-{}", i));
+            sink.sink(&verified).expect("should succeed");
+        }
+
+        assert_eq!(sink.len(), 5);
+        let values = sink.into_vec();
+        assert_eq!(
+            values,
+            vec!["value-0", "value-1", "value-2", "value-3", "value-4"]
+        );
+    }
+
+    #[test]
+    fn vec_sink_rejects_untrusted() {
+        let sink = VecSink::new();
+        let tainted = Tainted::new("unsafe data".to_string());
+
+        let result = sink.sink_untrusted(tainted);
+
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(error.kind(), SinkErrorKind::Unverified);
+
+        // Verify no side effects occurred
+        assert_eq!(sink.len(), 0);
+    }
+
+    #[test]
+    fn vec_sink_with_sanitizer() {
+        let sink = VecSink::new();
+        let sanitizer = StringSanitizer::new(256);
+
+        // Sanitize tainted input
+        let tainted = Tainted::new("  hello world  ".to_string());
+        let verified = sanitizer.sanitize(tainted).expect("valid input");
+
+        // Sink the verified value
+        sink.sink(&verified).expect("should succeed");
+
+        // Verify the trimmed value was stored
+        assert_eq!(sink.to_vec(), vec!["hello world"]);
+    }
+
+    #[test]
+    fn vec_sink_enforces_verified_type() {
+        let sink = VecSink::new();
+
+        // This compiles - verified values work:
+        let verified = Verified::new_unchecked("safe".to_string());
+        let _ = sink.sink(&verified);
+
+        // These would NOT compile if uncommented (good!):
+        // let raw_string = "raw".to_string();
+        // sink.sink(&raw_string); // Type mismatch!
+
+        // let tainted = Tainted::new("tainted".to_string());
+        // sink.sink(&tainted); // Type mismatch!
+    }
+
+    #[test]
+    fn vec_sink_default() {
+        let sink = VecSink::default();
+        assert!(sink.is_empty());
+        assert_eq!(sink.len(), 0);
+    }
+
+    #[test]
+    fn vec_sink_is_empty() {
+        let sink = VecSink::new();
+        assert!(sink.is_empty());
+
+        let verified = Verified::new_unchecked("test".to_string());
+        sink.sink(&verified).unwrap();
+
+        assert!(!sink.is_empty());
+    }
+
+    #[test]
+    fn vec_sink_preserves_sanitization() {
+        let sink = VecSink::new();
+        let sanitizer = StringSanitizer::new(50);
+
+        // Create multiple tainted inputs that need sanitization
+        let inputs = vec!["  one  ", "  two  ", "  three  "];
+
+        for input in inputs {
+            let tainted = Tainted::new(input.to_string());
+            let verified = sanitizer.sanitize(tainted).expect("valid");
+            sink.sink(&verified).expect("should succeed");
+        }
+
+        // All values should be trimmed
+        assert_eq!(sink.to_vec(), vec!["one", "two", "three"]);
+    }
+
+    #[test]
+    fn vec_sink_runtime_rejection_no_side_effects() {
+        let sink = VecSink::new();
+
+        // Add a verified value
+        let verified = Verified::new_unchecked("safe".to_string());
+        sink.sink(&verified).expect("should succeed");
+        assert_eq!(sink.len(), 1);
+
+        // Try to add tainted via runtime path
+        let tainted = Tainted::new("unsafe".to_string());
+        let result = sink.sink_untrusted(tainted);
+
+        // Should fail
+        assert!(result.is_err());
+
+        // Should not have modified the sink
+        assert_eq!(sink.len(), 1);
+        assert_eq!(sink.to_vec(), vec!["safe"]);
+    }
+}

--- a/src/tainted.rs
+++ b/src/tainted.rs
@@ -37,8 +37,18 @@ impl<T> Tainted<T> {
         Self { inner: value }
     }
 
-    // Note: No getter methods!
-    // Access will be added in Milestone 4 via sanitization.
+    /// Extracts the inner value for sanitization.
+    ///
+    /// # Safety (Policy-Level)
+    ///
+    /// This method is `pub(crate)` to restrict access to code within this crate.
+    /// It should ONLY be called by sanitizer implementations that will validate
+    /// the value before wrapping it in `Verified<T>`.
+    ///
+    /// External code cannot call this method and must go through the `Sanitizer` trait.
+    pub(crate) fn into_inner(self) -> T {
+        self.inner
+    }
 }
 
 impl<T: fmt::Debug> fmt::Debug for Tainted<T> {

--- a/src/verified.rs
+++ b/src/verified.rs
@@ -1,0 +1,193 @@
+/// A wrapper for data that has been validated/sanitized and is safe to use.
+///
+/// `Verified<T>` represents a value that has undergone validation or sanitization
+/// and can be safely passed to security-sensitive operations (sinks). Unlike raw values
+/// or [`Tainted<T>`](crate::Tainted), `Verified<T>` provides compile-time proof that
+/// the value has been processed through a controlled validation path.
+///
+/// # Construction Invariants
+///
+/// **IMPORTANT:** `Verified<T>` cannot be constructed directly by external code.
+/// There are no public constructors, and no `From<T>` or `Into<Verified<T>>` implementations
+/// that would allow arbitrary values to be wrapped.
+///
+/// Construction is restricted to crate-internal code through [`new_unchecked`](Self::new_unchecked),
+/// which is intentionally `pub(crate)`. Higher-level abstractions (e.g., `Sanitizer` in Milestone 4)
+/// are responsible for enforcing validation rules before calling this constructor.
+///
+/// # Access
+///
+/// Unlike [`Secret<T>`](crate::Secret) which requires explicit "scary" access,
+/// `Verified<T>` provides safe, ergonomic access to the underlying value:
+///
+/// - [`AsRef::as_ref`]: Borrow the verified value (via standard `AsRef<T>` trait)
+/// - [`into_inner`](Self::into_inner): Consume and extract the value
+///
+/// # Security Properties
+///
+/// - No public construction (enforces validation bottleneck)
+/// - Does NOT implement `Deref` (explicit access only)
+/// - Does NOT implement `Default` (no arbitrary "empty" verified values)
+/// - Safe to use in security-sensitive contexts
+///
+/// # Examples
+///
+/// External callers cannot create `Verified<T>` directly:
+///
+/// ```compile_fail
+/// use policy_core::Verified;
+///
+/// // This will not compile - no public constructor:
+/// let verified = Verified::new("data".to_string());
+/// ```
+///
+/// Access to verified values is explicit and ergonomic:
+///
+/// ```ignore
+/// // (This example requires crate-internal construction, shown for illustration only)
+/// use policy_core::Verified;
+///
+/// # fn get_verified_value() -> Verified<String> {
+/// #     // Only crate-internal code can do this:
+/// #     Verified::new_unchecked("safe-data".to_string())
+/// # }
+/// let verified = get_verified_value();
+///
+/// // Borrow the value
+/// let value_ref: &String = verified.as_ref();
+/// assert_eq!(value_ref, "safe-data");
+///
+/// // Or consume it
+/// let value: String = verified.into_inner();
+/// assert_eq!(value, "safe-data");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Verified<T> {
+    inner: T,
+}
+
+impl<T> Verified<T> {
+    /// Creates a `Verified<T>` without performing validation.
+    ///
+    /// # Safety (Policy-Level)
+    ///
+    /// This function is `pub(crate)` to restrict construction to code within this crate.
+    /// It does NOT perform any validation itself - callers are responsible for ensuring
+    /// that the value has been properly validated before wrapping it.
+    ///
+    /// Higher-level abstractions (e.g., `Sanitizer`) must enforce validation rules
+    /// before calling this constructor. This is a policy-level safety requirement,
+    /// not a memory-safety concern.
+    ///
+    /// # Usage
+    ///
+    /// This should only be called by trusted validation/sanitization code paths
+    /// within the crate that have verified the input according to appropriate rules.
+    #[allow(dead_code)] // Used by future sanitization code and tests
+    pub(crate) fn new_unchecked(value: T) -> Self {
+        Self { inner: value }
+    }
+
+    /// Consumes the `Verified<T>` and returns the inner value.
+    ///
+    /// Since the value has been verified, it's safe to extract and use directly.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// # use policy_core::Verified;
+    /// # let verified = Verified::new_unchecked("data".to_string());
+    /// let value = verified.into_inner();
+    /// assert_eq!(value, "data");
+    /// ```
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+/// Provides access to the verified value via the standard `AsRef` trait.
+///
+/// This allows `Verified<T>` to integrate seamlessly with Rust's standard library
+/// and other code that expects `AsRef<T>`.
+impl<T> AsRef<T> for Verified<T> {
+    fn as_ref(&self) -> &T {
+        &self.inner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verified_as_ref_returns_reference() {
+        let verified = Verified::new_unchecked("test-data".to_string());
+        let value_ref = verified.as_ref();
+
+        assert_eq!(value_ref, "test-data");
+        assert_eq!(value_ref.len(), 9);
+    }
+
+    #[test]
+    fn verified_into_inner_returns_value() {
+        let verified = Verified::new_unchecked(42);
+        let value = verified.into_inner();
+
+        assert_eq!(value, 42);
+    }
+
+    #[test]
+    fn verified_as_ref_does_not_consume() {
+        let verified = Verified::new_unchecked(vec![1, 2, 3]);
+
+        // Can call as_ref multiple times
+        let ref1 = verified.as_ref();
+        let ref2 = verified.as_ref();
+
+        assert_eq!(ref1, ref2);
+        assert_eq!(ref1, &vec![1, 2, 3]);
+
+        // Can still consume after borrowing
+        let value = verified.into_inner();
+        assert_eq!(value, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn verified_derives_work() {
+        let v1 = Verified::new_unchecked("data".to_string());
+        let v2 = v1.clone();
+
+        // Clone works
+        assert_eq!(v1, v2);
+
+        // Debug works
+        let debug_output = format!("{:?}", v1);
+        assert!(debug_output.contains("Verified"));
+        assert!(debug_output.contains("data"));
+    }
+
+    #[test]
+    fn verified_prevents_direct_construction() {
+        // This test documents that construction is restricted.
+        // If the following were uncommented, they would not compile:
+
+        // let v = Verified { inner: 42 }; // ← private field
+        // let v = Verified::new(42); // ← no such method
+        // let v: Verified<i32> = 42.into(); // ← no From impl
+
+        // Only internal code can construct:
+        let _ = Verified::new_unchecked(42);
+    }
+
+    #[test]
+    fn verified_no_deref() {
+        let verified = Verified::new_unchecked(String::from("test"));
+
+        // This would not compile if uncommented (good!):
+        // let s: &str = &*verified; // ← no Deref
+
+        // Must use explicit access:
+        let s: &String = verified.as_ref();
+        assert_eq!(s, "test");
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -251,7 +251,6 @@ fn ctx_log_fails_without_log_cap() {
 #[test]
 fn policy_log_redacts_secrets() {
     use tracing_subscriber::{Layer, layer::SubscriberExt};
-    use tracing_subscriber::{Layer, layer::SubscriberExt};
 
     // Capture log output
     let captured = Arc::new(Mutex::new(Vec::new()));


### PR DESCRIPTION
## Milestone 4 — Taint Tracking Demo

This PR completes Milestone 4 and resolves the full taint-tracking workflow, covering Issues #5 through #10.

### Issues included
- Closes #5
- Closes #6
- Closes #7
- Closes #8
- Closes #9 
- Closes #10 

### Summary
Milestone 4 establishes an end-to-end, type-safe taint tracking pipeline:

- Untrusted input enters as `Tainted<T>`
- Promotion to `Verified<T>` is only possible via explicit Sanitizers
- `Verified<T>` is unforgeable outside the crate
- Sinks accept only verified data on the main path (compile-time enforcement)
- Optional runtime rejection paths are explicit and side-effect free
- An internal demo proves the full flow without expanding the public API

Canonical flow demonstrated:
```
Tainted → Sanitized → Verified → Sink
```


### Guarantees
- No new dependencies
- No refactors to Milestones 1–3
- No implicit conversions (`Deref`, `From`, `Into`, etc.)
- No leakage of tainted input in errors or logs
- All side effects require verified data

### Verification
All checks pass on `milestone/4-taint-tracking`:
- `cargo fmt`
- `cargo clippy --all-features -- -D warnings`
- `cargo test --all-features`

### Notes
- Demo module is internal-only and not part of the public API
- This PR is intended to be merged into `dev`
