### PR TITLE
Milestone 6: Typestate contexts (Ctx<Unauthed → Authed → Authorized>)

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1,37 +1,191 @@
+use std::marker::PhantomData;
+
 use crate::capability::{HttpCap, LogCap};
 use crate::error::{Violation, ViolationKind};
 use crate::http::PolicyHttp;
 use crate::logging::PolicyLog;
+use crate::request::Principal;
+use crate::state::{Authed, Authorized, Unauthed};
 
 /// Execution context containing request metadata and capabilities.
 ///
-/// `Ctx` represents a validated execution environment. It holds:
-/// - Request metadata (request ID, user info, etc.)
-/// - Granted capabilities (proof that policies passed)
+/// `Ctx<S>` is generic over its authentication/authorization state:
+/// - `Ctx<Unauthed>`: No principal, no capabilities
+/// - `Ctx<Authed>`: Has principal, no capabilities
+/// - `Ctx<Authorized>`: Has principal and capabilities
+///
+/// # Type-State Progression
+///
+/// Contexts progress through states via explicit transitions:
+/// ```text
+/// Ctx<Unauthed> --authenticate--> Ctx<Authed> --authorize--> Ctx<Authorized>
+/// ```
+///
+/// Only `Ctx<Authorized>` can access privileged operations like logging and HTTP.
 ///
 /// # Construction
 ///
-/// `Ctx` cannot be constructed by user code. In Milestone 2, it will be
-/// created exclusively by `PolicyGate` after validating policies.
+/// `Ctx` cannot be constructed by user code. Use `PolicyGate` to obtain a
+/// fully validated `Ctx<Authorized>`, or use the state transition methods
+/// for manual progression.
 ///
 /// # Examples
 ///
-/// ```no_run
-/// // This will not compile - no public constructor:
-/// // let ctx = policy_core::Ctx::new("req-123".to_string());
+/// ```
+/// use policy_core::{PolicyGate, RequestMeta, Principal, Authenticated, Authorized};
+///
+/// // Using PolicyGate (returns Ctx<Authorized> directly):
+/// let meta = RequestMeta {
+///     request_id: "req-123".to_string(),
+///     principal: Some(Principal {
+///         id: "user-1".to_string(),
+///         name: "Alice".to_string(),
+///     }),
+/// };
+///
+/// let ctx = PolicyGate::new(meta)
+///     .require(Authenticated)
+///     .require(Authorized::for_action("log"))
+///     .build()
+///     .expect("policies satisfied");
+///
+/// // ctx is Ctx<Authorized> and can access privileged operations
+/// let logger = ctx.log().expect("LogCap granted");
 /// ```
 #[derive(Debug, Clone)]
-pub struct Ctx {
+pub struct Ctx<S = Authorized> {
     request_id: String,
+    principal: Option<Principal>,
     log_cap: Option<LogCap>,
     http_cap: Option<HttpCap>,
+    _state: PhantomData<S>,
 }
 
-impl Ctx {
+// ============================================================================
+// Shared methods (available on all states)
+// ============================================================================
+
+impl<S> Ctx<S> {
+    /// Returns the request ID for this context.
+    pub fn request_id(&self) -> &str {
+        &self.request_id
+    }
+
+    /// Returns the principal if present.
+    ///
+    /// Returns `Some(Principal)` for `Ctx<Authed>` and `Ctx<Authorized>`,
+    /// `None` for `Ctx<Unauthed>`.
+    pub fn principal(&self) -> Option<&Principal> {
+        self.principal.as_ref()
+    }
+}
+
+// ============================================================================
+// Ctx<Unauthed> - Initial state
+// ============================================================================
+
+impl Ctx<Unauthed> {
+    /// Creates a new unauthenticated context with only a request ID.
+    ///
+    /// This is `pub(crate)` so only code within policy-core can create it.
+    #[allow(dead_code)] // Used in tests
+    pub(crate) fn new_unauthed(request_id: String) -> Self {
+        Self {
+            request_id,
+            principal: None,
+            log_cap: None,
+            http_cap: None,
+            _state: PhantomData,
+        }
+    }
+
+    /// Authenticates the context by validating a principal.
+    ///
+    /// This transition requires a principal to be provided. If the principal
+    /// is valid, the context progresses to `Ctx<Authed>`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(Violation)` if the principal is `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// // This example shows the API but cannot be compiled in doctests
+    /// // because Ctx::new_unauthed is pub(crate). See unit tests for working examples.
+    /// use policy_core::{Ctx, Principal};
+    ///
+    /// let ctx = Ctx::new_unauthed("req-1".to_string());
+    /// let principal = Principal {
+    ///     id: "user-1".to_string(),
+    ///     name: "Alice".to_string(),
+    /// };
+    ///
+    /// let authed_ctx = ctx.authenticate(Some(principal)).expect("valid principal");
+    /// ```
+    pub fn authenticate(self, principal: Option<Principal>) -> Result<Ctx<Authed>, Violation> {
+        if let Some(p) = principal {
+            Ok(Ctx {
+                request_id: self.request_id,
+                principal: Some(p),
+                log_cap: None,
+                http_cap: None,
+                _state: PhantomData,
+            })
+        } else {
+            Err(Violation::new(
+                ViolationKind::Unauthenticated,
+                "Authentication required: principal not provided",
+            ))
+        }
+    }
+}
+
+// ============================================================================
+// Ctx<Authed> - Authenticated but not authorized
+// ============================================================================
+
+impl Ctx<Authed> {
+    /// Authorizes the context by granting capabilities.
+    ///
+    /// This transition validates that the authenticated principal has
+    /// permission to perform requested actions and grants corresponding
+    /// capabilities.
+    ///
+    /// # Arguments
+    ///
+    /// * `log_cap` - Optional logging capability
+    /// * `http_cap` - Optional HTTP capability
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// // Assuming we have a Ctx<Authed>:
+    /// let authorized_ctx = authed_ctx.authorize(Some(LogCap::new()), None);
+    /// ```
+    pub fn authorize(self, log_cap: Option<LogCap>, http_cap: Option<HttpCap>) -> Ctx<Authorized> {
+        Ctx {
+            request_id: self.request_id,
+            principal: self.principal,
+            log_cap,
+            http_cap,
+            _state: PhantomData,
+        }
+    }
+}
+
+// ============================================================================
+// Ctx<Authorized> - Fully authorized with capabilities
+// ============================================================================
+
+impl Ctx<Authorized> {
     /// Creates a new context with a request ID and optional capabilities.
     ///
-    /// This is `pub(crate)` so only code within policy-core can create Ctx.
+    /// This is `pub(crate)` so only code within policy-core can create it.
     /// PolicyGate calls this after validating policies.
+    ///
+    /// This is a compatibility shim for existing code that uses the old
+    /// non-generic Ctx API. New code should use state transitions.
     #[allow(dead_code)] // Will be used by PolicyGate
     pub(crate) fn new_unchecked(
         request_id: String,
@@ -40,14 +194,30 @@ impl Ctx {
     ) -> Self {
         Self {
             request_id,
+            principal: None,
             log_cap,
             http_cap,
+            _state: PhantomData,
         }
     }
 
-    /// Returns the request ID for this context.
-    pub fn request_id(&self) -> &str {
-        &self.request_id
+    /// Creates a new authorized context with full state.
+    ///
+    /// This is `pub(crate)` and used internally for state transitions
+    /// and PolicyGate integration.
+    pub(crate) fn new_authorized(
+        request_id: String,
+        principal: Option<Principal>,
+        log_cap: Option<LogCap>,
+        http_cap: Option<HttpCap>,
+    ) -> Self {
+        Self {
+            request_id,
+            principal,
+            log_cap,
+            http_cap,
+            _state: PhantomData,
+        }
     }
 
     /// Returns the logging capability if present.
@@ -200,5 +370,108 @@ mod tests {
             result.unwrap_err().kind,
             ViolationKind::MissingHttpCapability
         );
+    }
+
+    // ========================================================================
+    // Type-state tests
+    // ========================================================================
+
+    #[test]
+    fn unauthed_ctx_has_no_principal() {
+        let ctx = Ctx::new_unauthed("req-unauth".to_string());
+        assert_eq!(ctx.request_id(), "req-unauth");
+        assert!(ctx.principal().is_none());
+    }
+
+    #[test]
+    fn authenticate_with_principal_succeeds() {
+        let ctx = Ctx::new_unauthed("req-auth".to_string());
+        let principal = Principal {
+            id: "user-1".to_string(),
+            name: "Alice".to_string(),
+        };
+
+        let authed_ctx = ctx
+            .authenticate(Some(principal))
+            .expect("should authenticate");
+
+        assert_eq!(authed_ctx.request_id(), "req-auth");
+        assert!(authed_ctx.principal().is_some());
+        assert_eq!(authed_ctx.principal().unwrap().id, "user-1");
+    }
+
+    #[test]
+    fn authenticate_without_principal_fails() {
+        let ctx = Ctx::new_unauthed("req-auth-fail".to_string());
+
+        let result = ctx.authenticate(None);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind, ViolationKind::Unauthenticated);
+    }
+
+    #[test]
+    fn authorize_grants_capabilities() {
+        let ctx = Ctx::new_unauthed("req-authz".to_string());
+        let principal = Principal {
+            id: "user-2".to_string(),
+            name: "Bob".to_string(),
+        };
+
+        let authed_ctx = ctx.authenticate(Some(principal)).unwrap();
+        let authorized_ctx = authed_ctx.authorize(Some(LogCap::new()), Some(HttpCap::new()));
+
+        assert_eq!(authorized_ctx.request_id(), "req-authz");
+        assert!(authorized_ctx.principal().is_some());
+        assert!(authorized_ctx.log_cap().is_some());
+        assert!(authorized_ctx.http_cap().is_some());
+    }
+
+    #[test]
+    fn full_state_progression() {
+        // Unauthed -> Authed -> Authorized
+        let unauthed = Ctx::new_unauthed("req-progression".to_string());
+        assert!(unauthed.principal().is_none());
+
+        let principal = Principal {
+            id: "user-3".to_string(),
+            name: "Charlie".to_string(),
+        };
+        let authed = unauthed.authenticate(Some(principal)).unwrap();
+        assert!(authed.principal().is_some());
+
+        let authorized = authed.authorize(Some(LogCap::new()), None);
+        assert!(authorized.principal().is_some());
+        assert!(authorized.log_cap().is_some());
+        assert!(authorized.http_cap().is_none());
+    }
+
+    #[test]
+    fn authorized_ctx_can_access_log() {
+        let ctx = Ctx::new_authorized(
+            "req-log".to_string(),
+            Some(Principal {
+                id: "user-4".to_string(),
+                name: "Dana".to_string(),
+            }),
+            Some(LogCap::new()),
+            None,
+        );
+
+        assert!(ctx.log().is_ok());
+    }
+
+    #[test]
+    fn authorized_ctx_can_access_http() {
+        let ctx = Ctx::new_authorized(
+            "req-http".to_string(),
+            Some(Principal {
+                id: "user-5".to_string(),
+                name: "Eve".to_string(),
+            }),
+            None,
+            Some(HttpCap::new()),
+        );
+
+        assert!(ctx.http().is_ok());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ mod request;
 mod sanitizer;
 mod secret;
 mod sink;
+mod state;
 mod tainted;
 mod verified;
 
@@ -73,5 +74,6 @@ pub use sanitizer::{
 };
 pub use secret::Secret;
 pub use sink::{Sink, SinkError, SinkErrorKind, VecSink};
+pub use state::{Authed, Authorized as AuthorizedState, Unauthed};
 pub use tainted::Tainted;
 pub use verified::Verified;

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,7 +1,7 @@
 /// Metadata about an incoming request or operation.
 ///
 /// Contains the request identifier and optional principal (authenticated user/service).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RequestMeta {
     /// Unique identifier for this request
     pub request_id: String,
@@ -10,7 +10,7 @@ pub struct RequestMeta {
 }
 
 /// An authenticated user or service principal.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Principal {
     /// Unique identifier for this principal
     pub id: String,

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,89 @@
+//! Type-state markers for context progression.
+//!
+//! This module defines zero-sized marker types that encode the authentication
+//! and authorization state of a context at compile time.
+
+/// Marker type for an unauthenticated context.
+///
+/// `Ctx<Unauthed>` has no principal and cannot access privileged operations.
+#[derive(Debug, Clone, Copy)]
+pub struct Unauthed {
+    _private: (),
+}
+
+impl Unauthed {
+    /// Creates a new Unauthed marker.
+    ///
+    /// This is `pub(crate)` so only code within policy-core can create it.
+    #[allow(dead_code)] // Used in tests
+    pub(crate) fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+/// Marker type for an authenticated context.
+///
+/// `Ctx<Authed>` has a verified principal but has not been authorized
+/// for specific actions.
+#[derive(Debug, Clone, Copy)]
+pub struct Authed {
+    _private: (),
+}
+
+impl Authed {
+    /// Creates a new Authed marker.
+    ///
+    /// This is `pub(crate)` so only code within policy-core can create it.
+    #[allow(dead_code)] // Used in tests
+    pub(crate) fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+/// Marker type for an authorized context.
+///
+/// `Ctx<Authorized>` has a verified principal and has been authorized
+/// for specific actions. Only this state can access privileged operations.
+#[derive(Debug, Clone, Copy)]
+pub struct Authorized {
+    _private: (),
+}
+
+impl Authorized {
+    /// Creates a new Authorized marker.
+    ///
+    /// This is `pub(crate)` so only code within policy-core can create it.
+    #[allow(dead_code)] // Used in tests
+    pub(crate) fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_markers_are_zero_sized() {
+        assert_eq!(std::mem::size_of::<Unauthed>(), 0);
+        assert_eq!(std::mem::size_of::<Authed>(), 0);
+        assert_eq!(std::mem::size_of::<Authorized>(), 0);
+    }
+
+    #[test]
+    fn state_markers_cannot_be_constructed_publicly() {
+        // This test documents that state markers cannot be forged.
+        // If you uncomment these lines, they will not compile:
+
+        // let fake_unauthed = Unauthed { _private: () }; // Error: _private is private
+        // let fake_authed = Authed { _private: () }; // Error: _private is private
+        // let fake_authorized = Authorized { _private: () }; // Error: _private is private
+    }
+
+    #[test]
+    fn state_markers_can_be_created_internally() {
+        let _unauthed = Unauthed::new();
+        let _authed = Authed::new();
+        let _authorized = Authorized::new();
+    }
+}


### PR DESCRIPTION
## Milestone 6 — Type-State Contexts

Implements typestate contexts to encode policy progression in types:

Ctx<Unauthed> → Ctx<Authed> → Ctx<Authorized>

### Summary
- Added state markers: Unauthed, Authed, Authorized
- Made Ctx generic over state with default S = Authorized for backward compatibility
- Added explicit transitions:
  - authenticate: Ctx<Unauthed> -> Result<Ctx<Authed>, Violation>
  - authorize: Ctx<Authed> -> Ctx<Authorized>
- Restricted privileged methods (log/http/caps) to Ctx<Authorized> only
- Updated PolicyGate to return Ctx<Authorized> without changing the external call pattern
- Added unit + integration tests covering state restriction and transitions

### Guarantees
- No new dependencies
- Privileged operations are unavailable on Unauthed/Authed at compile time
- Existing sink/capability/verified invariants remain unchanged
