### PR TITLE
Extract action constants and add test-only context constructor

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -102,7 +102,7 @@ impl std::error::Error for Violation {}
 impl From<crate::SanitizationError> for Violation {
     fn from(err: crate::SanitizationError) -> Self {
         Violation::new(
-            ViolationKind::Unauthenticated,
+            ViolationKind::InvalidInput,
             format!("Sanitization failed: {}", err),
         )
     }
@@ -124,6 +124,8 @@ pub enum ViolationKind {
     MissingHttpCapability,
     /// Audit capability was not granted
     MissingAuditCapability,
+    /// Input validation failed (malformed, forbidden characters, etc.)
+    InvalidInput,
 }
 
 impl fmt::Display for ViolationKind {
@@ -155,6 +157,7 @@ impl fmt::Display for ViolationKind {
             ViolationKind::MissingLogCapability => write!(f, "Missing logging capability"),
             ViolationKind::MissingHttpCapability => write!(f, "Missing HTTP capability"),
             ViolationKind::MissingAuditCapability => write!(f, "Missing audit capability"),
+            ViolationKind::InvalidInput => write!(f, "Invalid input"),
         }
     }
 }
@@ -180,6 +183,7 @@ mod proptests {
             Just(ViolationKind::MissingLogCapability),
             Just(ViolationKind::MissingHttpCapability),
             Just(ViolationKind::MissingAuditCapability),
+            Just(ViolationKind::InvalidInput),
         ]
     }
 
@@ -241,6 +245,9 @@ mod proptests {
                 }
                 ViolationKind::MissingAuditCapability => {
                     prop_assert_eq!(display_output, "Missing audit capability");
+                }
+                ViolationKind::InvalidInput => {
+                    prop_assert_eq!(display_output, "Invalid input");
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ pub use error::{Error, Violation, ViolationKind};
 pub use gate::PolicyGate;
 pub use http::{HttpMethod, HttpRequest, PolicyHttp};
 pub use logging::PolicyLog;
-pub use policy::{Authenticated, Authorized};
+pub use policy::{Authenticated, Authorized, actions};
 pub use request::{Principal, RequestMeta};
 pub use sanitizer::{
     AcceptAllSanitizer, RejectAllSanitizer, SanitizationError, SanitizationErrorKind, Sanitizer,

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -10,6 +10,29 @@ pub enum PolicyReq {
     Authorized { action: &'static str },
 }
 
+/// Standard action names for authorization policies.
+///
+/// These constants define the canonical action names used throughout the crate.
+/// Using these constants instead of string literals prevents typos and provides
+/// a single source of truth for action names.
+///
+/// # Examples
+///
+/// ```
+/// use policy_core::{Authorized, actions};
+///
+/// let log_policy = Authorized::for_action(actions::LOG);
+/// let http_policy = Authorized::for_action(actions::HTTP);
+/// ```
+pub mod actions {
+    /// Logging action - grants LogCap capability
+    pub const LOG: &str = "log";
+    /// HTTP action - grants HttpCap capability
+    pub const HTTP: &str = "http";
+    /// Audit action - grants AuditCap capability
+    pub const AUDIT: &str = "audit";
+}
+
 /// Policy requiring authentication.
 ///
 /// Use this to require that a principal is present in the request metadata.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a public module exposing canonical action name constants for authorization policies, enabling consistent naming across implementations.

* **Bug Fixes**
  * Corrected error classification to properly distinguish invalid input errors from authentication failures, improving error handling accuracy.

* **Documentation**
  * Enhanced security considerations documentation detailing input validation threats and improved authorization flow documentation for clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->