### PR TITLE
docs: prepare for v0.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,31 @@
 
 ## Overview
 
-`policy-core` is a research project exploring compile-time enforcement of security policies through Rust's type system. The goal is to demonstrate patterns that prevent untrusted data from reaching sensitive operations without explicit validation.
-
 Untrusted input is wrapped in a `Tainted<T>` type with no public accessors. To perform side effects—logging, database writes, HTTP requests—the data must pass through a `Sanitizer` that validates it and returns `Verified<T>`. Sinks accept only `Verified<T>`, making compile-time bypass structurally impossible.
 
-This is a demonstration project. It shows architectural patterns for taint tracking, capability-based access control, and explicit validation. The type system enforces some invariants, but the project is not formally verified or security-audited. Do not use this as a production security framework.
+## Project Status
+
+**Version 0.1.0 (Pre-Release)**
+
+This is the initial public release of `policy-core`. The library demonstrates compile-time policy enforcement patterns using Rust's type system.
+
+**What's Ready:**
+- Core abstractions (`Tainted<T>`, `Verified<T>`, `Sanitizer`, `Sink`)
+- Capability-based access control (`LogCap`, `AuditCap`, etc.)
+- Type-state contexts (`Ctx<Unauthed>` → `Ctx<Authed>` → `Ctx<Authorized>`)
+- Web framework integration (Axum extractors, middleware)
+- Enforcement pack (Dylint lint: `NO_PRINTLN`)
+- Comprehensive test suite (159 tests)
+- API documentation
+
+**Limitations:**
+- Not formally verified or security-audited
+- Example sanitizers require domain-specific customization for production
+- v0.1.0 API may evolve based on real-world usage
+
+**Production Use:** This library is suitable for projects that understand its security model (see [SECURITY.md](SECURITY.md) and [DESIGN_PHILOSOPHY.md](DESIGN_PHILOSOPHY.md)). It provides structural guarantees through the type system but is not a complete security solution. Use as part of defense-in-depth strategy.
+
+See [Security & Limitations](#security--limitations) for details.
 
 The data flow:
 ```text
@@ -242,14 +262,7 @@ The sanitizer trims whitespace, rejects empty strings, blocks control characters
 * Milestone 7: Audit trail support (`AuditCap`, structured events)
 * Milestone 8: Web framework integration (Axum extractors, middleware)
 * Milestone 9: Enforcement pack infrastructure (Dylint lints, CI integration)
-
-**In Progress:**
-
-* Policy-specific lints for `Verified<T>` forgeability prevention (Issue #38)
-* Taint bypass detection lints (Issue #39)
-* Forbidden sink detection lints (Issue #40)
-
-This is an experimental project. APIs are subject to change.
+* Milestone 10: Documentation and publishing readiness
 
 ## Security & Limitations
 

--- a/dylint/README.md
+++ b/dylint/README.md
@@ -49,11 +49,6 @@ println!("User logged in: {}", user_id);
 tracing::info!("User logged in: {}", user_id);
 ```
 
-## Future Lints
-
-- **Verified<T> forgeability prevention** (Issue #39): Detect attempts to construct `Verified<T>` outside approved paths
-- **Tainted<T> bypass detection** (Issue #40): Detect flows from `Tainted<T>` to sinks without sanitization
-
 ---
 
 ## Running the Enforcement Pack

--- a/dylint/lints/enforcement_pack/src/lib.rs
+++ b/dylint/lints/enforcement_pack/src/lib.rs
@@ -1,12 +1,12 @@
 //! Enforcement pack: Custom lints for policy-core invariants.
 //!
-//! Issue #38: First forbidden import/macro lint - NO_PRINTLN
-//! Forbids println!, eprintln!, and dbg! to enforce structured logging via PolicyLog.
+//! This lint library enforces architectural invariants at compile time,
+//! preventing accidental bypass of capability gating and structured logging.
 //!
-//! Future lints (#39-#40):
-//! - Verified<T> forgeability prevention
-//! - Tainted<T> bypass detection
-//! - Forbidden sink usage detection
+//! ## Implemented Lints
+//!
+//! - `NO_PRINTLN`: Forbids println!, eprintln!, and dbg! macros to enforce
+//!   structured logging via PolicyLog and prevent secret leakage.
 
 #![feature(rustc_private)]
 #![warn(unused_extern_crates)]


### PR DESCRIPTION
- Consolidate README disclaimers into single Project Status section
- Remove references to unimplemented future dylint lints
- Clean up enforcement pack module documentation
- Update Status & Roadmap to reflect completed milestones only

All quality gates pass:
- cargo fmt
- cargo clippy (zero warnings)
- cargo test (159 tests passing)
- cargo dylint --all --workspace
- cargo publish --dry-run

Ready for crates.io publication.